### PR TITLE
Improve API class by deduplicating variants and saving an attribute as a list

### DIFF
--- a/src/id3_variants_training/ga4gh_API.py
+++ b/src/id3_variants_training/ga4gh_API.py
@@ -92,8 +92,9 @@ class GA4GH_API:
             'referenceName': chrom
         }
         r = requests.post('%s%s' %  (self.host_url, 'variants/search'), json=req_body).json()
-        for variant in r['results']['variants']:
-            variant_list.append(':'.join([chrom, variant['start'], variant['end']]))
+        if 'results' in r:
+            for variant in r['results']['variants']:
+                variant_list.append(':'.join([chrom, variant['start'], variant['end']]))
         return variant_list
 
 

--- a/src/id3_variants_training/ga4gh_API.py
+++ b/src/id3_variants_training/ga4gh_API.py
@@ -173,7 +173,7 @@ class GA4GH_API:
         req =  self.craft_api_request()
         ancestry_counts = requests.post('%s%s' %  (self.host_url, 'count'), json=req).json()['results']['patients'][0]['ethnicity']
         if self.ancestry_list == []:
-            self.ancestry_list = ancestry_counts.keys()
+            self.ancestry_list = list(ancestry_counts.keys())
 
         return ancestry_counts
 

--- a/src/id3_variants_training/ga4gh_API.py
+++ b/src/id3_variants_training/ga4gh_API.py
@@ -68,7 +68,7 @@ class GA4GH_API:
         variant_list = []
         for var_range in self.config['variant_ranges']:
             variant_list.extend(self.query_variants(str(var_range['chr']), str(var_range['start']), str(var_range['end'])))
-        return variant_list
+        return list(set(variant_list))    # deduplicate list
 
     def query_variants(self, chrom, start, end):
         """


### PR DESCRIPTION
When generating the variant list over the CanDIG APIs, the list produces a large number of duplicates (the variant is counted once per patient in which it occurs).  This is due to how the APIs have changed in the last couple of years.

Two changes are made here - we deduplicate the list of variants.  Unrelatedly, another change turns one of the attributes of an ID3 object to a list (it was already a list in Python2 but in Python3 it's an iterator)