### PR TITLE
Modified __train__ and __predict__ so that they work with setup.py co…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setuptools.setup(
     install_requires=install_requires,
     entry_points={
         'console_scripts': [
-            'train-id3=id3_variants_training.__train__:train',
-            'predict-id3=id3_variants_training.__predict__:predict'
+            'train-id3=id3_variants_training.__train__:train_main',
+            'predict-id3=id3_variants_training.__predict__:predict_main'
         ],
     },
 )

--- a/src/id3_variants_training/__predict__.py
+++ b/src/id3_variants_training/__predict__.py
@@ -5,19 +5,19 @@ from .ConfusionMatrix import ConfusionMatrix
 from .local_API import LOCAL_API
 
 
-def get_confusion_matrix(config_path, id3_tree):
+def predict(config_path, id3_tree):
     api = LOCAL_API(config_path, False)
     return ConfusionMatrix(id3_tree, api)
 
 
-def predict():
+def predict_main():
     parser = argparse.ArgumentParser()
     parser.add_argument('config_path', help='path to the config file that contains vcf file paths', default='config.json')
     parser.add_argument('model_file', help='path to output ID3 file', type=argparse.FileType('rb'))
     args = parser.parse_args()
 
     id3_model = pickle.load(args.model_file)
-    conf_matrix = get_confusion_matrix(args.config_path, id3_model)
+    conf_matrix = predict(args.config_path, id3_model)
     numpy.set_printoptions(linewidth=10000)
     print(conf_matrix)
     print(conf_matrix.get_accuracy())

--- a/src/id3_variants_training/__predict__.py
+++ b/src/id3_variants_training/__predict__.py
@@ -4,18 +4,20 @@ import numpy
 from .ConfusionMatrix import ConfusionMatrix
 from .local_API import LOCAL_API
 
-def predict(config_path, id3_tree):
+
+def get_confusion_matrix(config_path, id3_tree):
     api = LOCAL_API(config_path, False)
     return ConfusionMatrix(id3_tree, api)
 
-if __name__ == '__main__':
+
+def predict():
     parser = argparse.ArgumentParser()
     parser.add_argument('config_path', help='path to the config file that contains vcf file paths', default='config.json')
     parser.add_argument('model_file', help='path to output ID3 file', type=argparse.FileType('rb'))
     args = parser.parse_args()
 
     id3_model = pickle.load(args.model_file)
-    conf_matrix = predict(args.config_path, id3_model)
+    conf_matrix = get_confusion_matrix(args.config_path, id3_model)
     numpy.set_printoptions(linewidth=10000)
     print(conf_matrix)
     print(conf_matrix.get_accuracy())

--- a/src/id3_variants_training/__train__.py
+++ b/src/id3_variants_training/__train__.py
@@ -5,7 +5,7 @@ from .ga4gh_API import GA4GH_API
 from .ID3_Class import ID3
 
 
-def train(use_local, config_path, verbose=True):
+def get_id3_tree(use_local, config_path, verbose=True):
     if use_local:
         api = LOCAL_API(config_path, False)
     else:
@@ -13,7 +13,8 @@ def train(use_local, config_path, verbose=True):
 
     return ID3(api, verbose)
 
-if __name__ == '__main__':
+
+def train():
     parser = argparse.ArgumentParser()
     parser.add_argument('config_file', help='path to the config file that contains variant ranges in JSON format', default='config.json')
     parser.add_argument('model_file', help='path to output ID3 file', type=argparse.FileType('wb'))
@@ -25,9 +26,8 @@ if __name__ == '__main__':
     use_local_vcf_files = not args.use_candig_apis
     config_file_path = args.config_file
 
-    id3_tree = train(use_local_vcf_files, config_file_path)
+    id3_tree = get_id3_tree(use_local_vcf_files, config_file_path)
 
     pickle.dump(id3_tree, args.model_file)
     if args.diagram:
         id3_tree.print_tree(args.diagram)
-

--- a/src/id3_variants_training/__train__.py
+++ b/src/id3_variants_training/__train__.py
@@ -5,7 +5,7 @@ from .ga4gh_API import GA4GH_API
 from .ID3_Class import ID3
 
 
-def get_id3_tree(use_local, config_path, verbose=True):
+def train(use_local, config_path, verbose=True):
     if use_local:
         api = LOCAL_API(config_path, False)
     else:
@@ -14,7 +14,7 @@ def get_id3_tree(use_local, config_path, verbose=True):
     return ID3(api, verbose)
 
 
-def train():
+def train_main():
     parser = argparse.ArgumentParser()
     parser.add_argument('config_file', help='path to the config file that contains variant ranges in JSON format', default='config.json')
     parser.add_argument('model_file', help='path to output ID3 file', type=argparse.FileType('wb'))
@@ -26,7 +26,7 @@ def train():
     use_local_vcf_files = not args.use_candig_apis
     config_file_path = args.config_file
 
-    id3_tree = get_id3_tree(use_local_vcf_files, config_file_path)
+    id3_tree = train(use_local_vcf_files, config_file_path)
 
     pickle.dump(id3_tree, args.model_file)
     if args.diagram:

--- a/test_local.py
+++ b/test_local.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import numpy
 import pytest
-from src.id3_variants_training.__train__ import train
-from src.id3_variants_training.__predict__ import predict
+from id3_variants_training.__train__ import train
+from id3_variants_training.__predict__ import predict
 
 @pytest.fixture
 def model_case1_train():


### PR DESCRIPTION
…mmand line scripts.

I made a change to __train__ and __predict__ so that it works when it's packaged. Basically if __name__ == '__main__': doesn't work with console scripts in setup.py so I just put that code block into its own separate function which is called by setup.py.